### PR TITLE
Add verbosity flag to emrlist

### DIFF
--- a/setenv.sh
+++ b/setenv.sh
@@ -97,7 +97,11 @@ function emrproxy {
 }
 
 function emrlist {
- emr --list
+ local opts=""
+ if [[ $* != *-v* ]]; then
+  opts="$opts --no-steps --active"
+ fi
+ emr --list $opts
 }
 
 function emrstat {


### PR DESCRIPTION
I offen use `emrlist` to check state of my clusters, but it works extremely slow and output is huge. 
