### PR TITLE
Add force flag to emrterminate

### DIFF
--- a/setenv.sh
+++ b/setenv.sh
@@ -110,7 +110,9 @@ function emrstat {
 }
 
 function emrterminate {
+ if [ "$1" == -f ]; then f=1; shift; fi
  FLOW_ID=`flowid $1`
+ [ -n "$f" ] && emr -j $FLOW_ID --set-termination-protection false
  emr -j $FLOW_ID --terminate
  export EMR_FLOW_ID=""
 }


### PR DESCRIPTION
EMR Ruby CLI and AWS Web Console set termination protection up by default.
Force flag turn protection off before attempt to terminate.
